### PR TITLE
Add instructions for working from a fork

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,35 @@ You may **substitute** `git annex get` with more specific commands if you are on
 git annex get sub-douglas sub-juntendoPrisma/anat/
 ```
 
+## Working from a forked repository
+
+> ⚠️ For advanced users only. Normally the instructions under [Download](#Download) should be enough.
+If you have forked this repository on Github (so that you have a copy `your-user-name/data-single-subject` of `spine-generic/data-single-subject`), you will need to take a few extra synchronization steps to get the latest data with `git annex get`. Otherwise, you may get an error message like:
+```
+get some-file-name.nii.gz (not available)
+  No other repository is known to contain the file.
+  (Note that these git remotes have annex-ignore set: origin)
+failed
+```
+
+1. In your local clone of `your-user-name/data-single-subject`, make sure that `spine-generic/data-single-subject` is also configured as a remote:
+   ```
+   git remote -v
+   # the answer should show both your-user-name/data-single-subject.git (probably named "origin")
+   # and spine-generic/data-single-subject (probably named "upstream")
+   ```
+
+   If `spine-generic/data-single-subject` is missing, you can add it with:
+   ```
+   git remote add upstream https://github.com/spine-generic/data-single-subject.git
+   git config remote.upstream.annex-readonly true
+   ```
+
+2. Then, to update your local clone, make sure to fetch the `git-annex` branch from `spine-generic/data-single-subject` before running `git annex get`:
+   ```
+   git fetch upstream +refs/heads/git-annex:refs/remotes/upstream/git-annex
+   git pull && git annex get .
+   ```
 
 ## Analysis
 


### PR DESCRIPTION
See also the corresponding change at [data-multi-subject#129](https://github.com/spine-generic/data-multi-subject/pull/129).

This change may be less relevant in this repository than in [data-multi-subject](https://github.com/spine-generic/data-multi-subject), since we currently only have 3 forks on Github ([link](https://github.com/spine-generic/data-single-subject/network/members)).