### PR TITLE
Upgrade to spine-generic@v2.3.1

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -21,7 +21,7 @@ jobs:
     - name: before_install
       run: |
         # install spine-generic for acquisition parameters check
-        pip install spinegeneric@git+https://github.com/spine-generic/spine-generic.git@v2.3
+        pip install spinegeneric@git+https://github.com/spine-generic/spine-generic.git@v2.3.1
         # use conda's git-annex, because it's the most up to date;
         # Debian's is very behind, and even neurodebian's is behind
         # by a year, and is currently incompatible with the format of this repo.


### PR DESCRIPTION
This is a minimal fix to get CI to run again.

See the [release notes](https://github.com/spine-generic/spine-generic/releases/tag/v2.3.1) for the contents of the change (just a rename of `sklearn` to `scikit-learn` in `requirements.txt`).