### PR TITLE
Revamp github actions validation workflow

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -50,8 +50,12 @@ jobs:
         pip install spinegeneric@git+https://github.com/spine-generic/spine-generic.git@v2.9
 
     - name: Run bids-validator
+      # If the explicit whitelist of allowed environment variables gets too annoying to update,
+      # we can loosen it to just a blanket `--allow-env`. This will let bids-validator and all of its
+      # dependencies access any credentials that github CI exposes in environment variables, but at
+      # least we're not giving it any network access, so exfiltrating them would require more effort.
       run: |
-        deno run --no-prompt --allow-env=BIDS_SCHEMA,FORCE_COLOR --allow-read=. jsr:@bids/validator .
+        deno run --no-prompt --allow-env=BIDS_SCHEMA,FORCE_COLOR,IGNORE_TEST_WIN32 --allow-read=. jsr:@bids/validator .
 
     - name: Run acquisition parameter validator
       # we ignore the exit code because we expect warnings, but we still want

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -50,16 +50,20 @@ jobs:
         pip install spinegeneric@git+https://github.com/spine-generic/spine-generic.git@v2.9
 
     - name: Run bids-validator
+      # I would prefer to whitelist the allowed environment variables,
+      # but upstream adds new ones unpredictably. At least we don't
+      # allow any network access.
       run: |
-        # I would prefer to whitelist the allowed environment variables,
-        # but upstream adds new ones unpredictably. At least we don't
-        # allow any network access.
         deno run --no-prompt --allow-env --allow-read=. jsr:@bids/validator .
 
     - name: Run acquisition parameter validator
+      # we ignore the exit code because we expect warnings, but we still want
+      # to see them
       run: |
-        sg_params_checker -path-in .
+        sg_params_checker -path-in . || true
 
     - name: Run data consistency validator
+      # we ignore the exit code because we expect warnings, but we still want
+      # to see them
       run: |
-        sg_check_data_consistency -path-in .
+        sg_check_data_consistency -path-in . || true

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -7,59 +7,59 @@ on:
     branches: [ master ]
 
 jobs:
-  build:
-
+  Validate:
     runs-on: ubuntu-latest
-
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python 3.7
-      uses: actions/setup-python@v2
-      with:
-        python-version: 3.7
 
-    - name: before_install
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        # download from the PR's repo (which may be a fork), because we also
+        # need the git-annex branch from that repo
+        repository: ${{github.event.pull_request.head.repo.full_name}}
+        ref: ${{github.event.pull_request.head.ref}}
+
+    - name: Install git-annex
       run: |
-        # install spine-generic for acquisition parameters check
-        pip install spinegeneric@git+https://github.com/spine-generic/spine-generic.git@v2.3.1
-        # use conda's git-annex, because it's the most up to date;
-        # Debian's is very behind, and even neurodebian's is behind
-        # by a year, and is currently incompatible with the format of this repo.
-        wget -O/tmp/Miniconda3-latest-Linux-x86_64.sh https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh
-        bash /tmp/Miniconda3-latest-Linux-x86_64.sh -b -f
-        source ~/miniconda3/bin/activate # careful! after this we're no longer in GH action's python, we're in conda's!
-        conda install -y -c conda-forge git-annex
-        # install proper NodeJS for bids-validator
-        sudo rm -rf ~/.nvm
-        curl -sL https://deb.nodesource.com/setup_current.x | sudo -E bash -
-        sudo apt-get install -y nodejs
-        sudo npm install -g bids-validator
-    - name: Include miniconda in PATH
-      run: |
-        echo "$HOME/miniconda3/bin" >> $GITHUB_PATH
-        echo "$HOME/miniconda3/Scripts" >> $GITHUB_PATH
+        sudo apt-get update
+        sudo apt-get --yes install git-annex
+        # the user name and email is needed by git-annex to write to
+        # the local git-annex branch
         git config --global user.name "gh-actions"
         git config --global user.email "gh-actions"
-    - name: setup
+        # save space by using hard links to annexed files
+        git config --global annex.thin true
+        # retry for transient failures when downloading annexed file contents
+        git config --global annex.retry 2
+
+    - name: Download dataset
       run: |
-        # download the data content
-        git fetch origin git-annex:git-annex # Travis does a shallow checkout, so it is missing this important branch
-        git annex init
-    - name: download data
-      run: |        
-        echo -e "\e[1m \e[4m \e[34mDownloading dataset; this will take a while. \n"
-        # this is -q because git-annex doesn't have a short progress bar like git
-        # and the download log is overwhelming and not interesting and might trip over
-        #    https://docs.travis-ci.com/user/common-build-problems/#log-length-exceeded.
-        # but -q might instead trip over
-        #   https://docs.travis-ci.com/user/common-build-problems/#build-times-out-because-no-output-was-received
-        # so it's a balancing act.
-        git annex get -J8
-    - name: script
+        git fetch --depth=1 origin git-annex:git-annex
+        git annex get --jobs 8
+
+    - name: Install Deno
+      uses: denoland/setup-deno@v2
+
+    - name: Install Python 3.13
+      uses: actions/setup-python@v5
+      with:
+        python-version: 3.13
+
+    - name: Install spine-generic
       run: |
-        echo -e "\e[1m \e[4m \e[34mRunning BIDS-validator \n"
-        bids-validator ./
-        echo -e "\e[1m \e[4m \e[34mChecking acquisition parameters \n"
-        sg_params_checker -path-in ./
-        echo -e "\e[1m \e[4m \e[34mChecking data consistency \n"
-        sg_check_data_consistency -path-in ./
+        pip install spinegeneric@git+https://github.com/spine-generic/spine-generic.git@v2.9
+
+    - name: Run bids-validator
+      run: |
+        # I would prefer to whitelist the allowed environment variables,
+        # but upstream adds new ones unpredictably. At least we don't
+        # allow any network access.
+        deno run --no-prompt --allow-env --allow-read=. jsr:@bids/validator .
+
+    - name: Run acquisition parameter validator
+      run: |
+        sg_params_checker -path-in .
+
+    - name: Run data consistency validator
+      run: |
+        sg_check_data_consistency -path-in .

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -50,11 +50,8 @@ jobs:
         pip install spinegeneric@git+https://github.com/spine-generic/spine-generic.git@v2.9
 
     - name: Run bids-validator
-      # I would prefer to whitelist the allowed environment variables,
-      # but upstream adds new ones unpredictably. At least we don't
-      # allow any network access.
       run: |
-        deno run --no-prompt --allow-env --allow-read=. jsr:@bids/validator .
+        deno run --no-prompt --allow-env=BIDS_SCHEMA,FORCE_COLOR --allow-read=. jsr:@bids/validator .
 
     - name: Run acquisition parameter validator
       # we ignore the exit code because we expect warnings, but we still want


### PR DESCRIPTION
Sorry, I didn't separate it into distinct commits, but the intended changes are to:
- Generally update the versions of the github actions we use.
- Stop using conda, since we can now get a recent-enough version of git-annex directly from apt.
- Switch from nodejs to deno, since upstream bids-validator switched.
- Update the spine-generic validator to a current version, and Python as well.

The general inspiration was https://github.com/spine-generic/data-multi-subject/pull/180.